### PR TITLE
Discussed updates

### DIFF
--- a/src/world/fluff/FluffBlockDropListener.java
+++ b/src/world/fluff/FluffBlockDropListener.java
@@ -5,7 +5,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.block.Biome;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Guardian;
@@ -151,8 +150,8 @@ public class FluffBlockDropListener implements Listener {
 					
 					if(ThreadLocalRandom.current().nextInt(5) == 3) //20% chance of dropping
 					{
-						//Without creepers, we need a source for gunpowder. Skeletons will drop 0-3 gunpowder.
-						event.getDrops().add(new ItemStack(Material.SULPHUR, ThreadLocalRandom.current().nextInt(4)));
+						//Without creepers, we need a source for gunpowder. Skeletons will drop 0-2 gunpowder.
+						event.getDrops().add(new ItemStack(Material.SULPHUR, ThreadLocalRandom.current().nextInt(3)));
 					}
 				}
 			}
@@ -292,4 +291,5 @@ public class FluffBlockDropListener implements Listener {
 			fwdb.givePlayerPoints(name, amount);
 		}
 	}
+	
 }

--- a/src/world/fluff/FluffBlockDropListener.java
+++ b/src/world/fluff/FluffBlockDropListener.java
@@ -8,7 +8,10 @@ import org.bukkit.Material;
 import org.bukkit.block.Biome;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Guardian;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Skeleton;
+import org.bukkit.entity.Skeleton.SkeletonType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.inventory.ItemStack;
@@ -136,13 +139,14 @@ public class FluffBlockDropListener implements Listener {
 			}
 			else if(ent == EntityType.SKELETON)
 			{
-				if(event.getEntity().getKiller().getWorld().getBiome(player.getLocation().getBlockX(), player.getLocation().getBlockZ()) == Biome.HELL)
+				Skeleton s = (Skeleton) event.getEntity();
+				
+				if(s.getSkeletonType() == SkeletonType.WITHER)
 				{
 					fwdb.givePlayerPoints(name, 4);
 				}
 				else
 				{
-					
 					fwdb.givePlayerPoints(name, 1);
 					
 					if(ThreadLocalRandom.current().nextInt(5) == 3) //20% chance of dropping
@@ -151,7 +155,6 @@ public class FluffBlockDropListener implements Listener {
 						event.getDrops().add(new ItemStack(Material.SULPHUR, ThreadLocalRandom.current().nextInt(4)));
 					}
 				}
-				//Must check if Entity Data -> SkeletonType == 1 for Wither Skeleton
 			}
 			else if(ent == EntityType.ZOMBIE)
 			{
@@ -163,7 +166,7 @@ public class FluffBlockDropListener implements Listener {
 			}
 			else if(ent == EntityType.GHAST)
 			{
-				fwdb.givePlayerPoints(name, 4);
+				fwdb.givePlayerPoints(name, 6); //point count subject to change
 			}
 			else if(ent == EntityType.SPIDER)
 			{
@@ -184,6 +187,18 @@ public class FluffBlockDropListener implements Listener {
 			else if(ent == EntityType.ENDERMITE)
 			{
 				fwdb.givePlayerPoints(name, 1);
+			}
+			else if(ent == EntityType.GUARDIAN)
+			{
+				Guardian g = (Guardian) event.getEntity();
+				if(g.isElder()) {
+					//The big boss Guardian
+					fwdb.givePlayerPoints(name, 350); //point count subject to change
+				}
+				else
+				{
+					fwdb.givePlayerPoints(name, 15); //point count subject to change
+				}
 			}
 		}
 	}

--- a/src/world/fluff/FluffWorldIntegration.java
+++ b/src/world/fluff/FluffWorldIntegration.java
@@ -31,9 +31,30 @@ public class FluffWorldIntegration extends JavaPlugin {
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (command.getName().equalsIgnoreCase("points"))
         {
-        	int p = fwdb.getPlayerPoints(sender.getName());
-            sender.sendMessage("You have " + p + " FWMC points.");
-            return true;
+        	
+        	if(args.length == 0)
+        	{
+        		int p = fwdb.getPlayerPoints(sender.getName());
+                sender.sendMessage("You have " + p + " FWMC points.");
+                return true;
+        	}
+        	else
+        	{        		
+        		if(fwdb.checkIfNameInDb(args[0]))
+        		{
+        			//the requested user is in the database
+        			int p = fwdb.getPlayerPoints(args[0]);
+                    sender.sendMessage("Player "+args[0]+" has " + p + " FWMC points.");
+                    return true;
+        		}
+        		else 
+        		{
+        			//the requested user is NOT in the database
+        			sender.sendMessage("Player "+args[0]+" is not in the database.");
+        			return false;
+        		}
+        	}
+        	
         }
         else if(command.getName().equalsIgnoreCase("chatcolor"))
         {

--- a/src/world/fluff/FluffWorldIntegration.java
+++ b/src/world/fluff/FluffWorldIntegration.java
@@ -16,7 +16,6 @@ public class FluffWorldIntegration extends JavaPlugin {
 	// Fired when plugin is first enabled
     @Override
     public void onEnable() {
-    	System.out.println("FluffWorldIntegration enabled!");
     	fwdb = new FWDBConnection();
     	fsb = new FluffsScoreboard(Bukkit.getScoreboardManager().getNewScoreboard());
     	getServer().getPluginManager().registerEvents(new FluffBlockDropListener(fwdb, fsb), this);

--- a/src/world/fluff/FluffsScoreboard.java
+++ b/src/world/fluff/FluffsScoreboard.java
@@ -1,5 +1,6 @@
 package world.fluff;
 
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.scoreboard.DisplaySlot;
 import org.bukkit.scoreboard.Scoreboard;
@@ -10,6 +11,7 @@ public class FluffsScoreboard {
 	{
 		fwScoreboard = fsb;
 		createXPObjective();
+		createHealthObjective();
 		//createPointsObjective();
 	}
 	
@@ -21,8 +23,17 @@ public class FluffsScoreboard {
 	
 	private void createXPObjective()
 	{
+		//Player Experience
 		fwScoreboard.registerNewObjective("XP", "CURRENT_XP");
 		fwScoreboard.getObjective("XP").setDisplaySlot(DisplaySlot.PLAYER_LIST);
+	}
+	
+	private void createHealthObjective()
+	{
+		//Player Health
+		fwScoreboard.registerNewObjective("health", "health"); //(String name, String criteriaType)
+		fwScoreboard.getObjective("health").setDisplayName(ChatColor.RED+"\u2665");
+		fwScoreboard.getObjective("health").setDisplaySlot(DisplaySlot.BELOW_NAME);
 	}
 	
 	public Scoreboard getScoreboard()
@@ -33,6 +44,7 @@ public class FluffsScoreboard {
 	public void kill()
 	{
 		fwScoreboard.getObjective("XP").unregister();
+		fwScoreboard.getObjective("health").unregister();
 	}
 	
 	/*public void refreshPlayerPoints(String name)


### PR DESCRIPTION
**Because I did not get to test most of these on the actual server, please review the code and run some tests of the following changes:**
- Guardians now give points when defeated (subject to change)
  - Normal guardians: 15 points
  - Elder guardians: 350 points
- Ghasts give 6 points instead of 4
- Skeletons now properly give points based on SkeletonType, not killer
  biome location
- Added 'health' objective to display health below player names
- /points command now lets you check other player's points
- Tweaked skeleton sulphur drop count to be 0-2 instead of 0-3
